### PR TITLE
Revamp contact section layout and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,39 @@ section { padding:4rem 0; }
 #reviews .review-role { font-size:14px; font-style:italic; color:var(--muted); margin-bottom:8px; }
 #reviews .review-text { font-size:16px; line-height:1.6; color:var(--muted); }
 @media (max-width:575.98px){ #reviews .review-item{ flex-direction:column; margin-bottom:28px; } #reviews .review-item:last-child{ margin-bottom:0; } #reviews .review-avatar{ margin-bottom:1rem; } }
+
+/* Contact section */
+#contact { background:var(--bg); padding:88px 0; }
+@media (max-width:767.98px){ #contact{ padding:44px 0; } }
+@media (min-width:768px) and (max-width:991.98px){ #contact{ padding:60px 0; } }
+#contact .contact-title{ font-family:'Forum',serif; font-size:40px; letter-spacing:0.6px; color:var(--ink); text-transform:uppercase; margin-bottom:32px; text-align:left; }
+#contact .contact-info a{ text-decoration:none; display:block; }
+#contact .contact-phone{ color:var(--ink); font-size:16px; line-height:1.6; }
+#contact .contact-phone:hover{ color:#1F1F1F; text-decoration:underline; }
+#contact .contact-email{ color:var(--muted); font-size:15px; line-height:1.6; }
+#contact .contact-email:hover{ color:var(--ink); text-decoration:underline; }
+#contact .messenger-list{ list-style:none; padding:0; margin-top:22px; }
+#contact .messenger-list li{ font-size:15px; color:var(--muted); display:flex; align-items:center; gap:8px; margin-bottom:8px; }
+#contact .messenger-list li::before{ content:""; width:12px; height:12px; border:1px solid #D0D6DC; border-radius:50%; }
+#contact .form-label{ font-size:13px; color:var(--muted); margin-bottom:2px; }
+#contact .form-line{ border:0; border-bottom:1px solid #AEB7BF; border-radius:0; background:transparent; padding:10px 0; height:48px; }
+#contact .form-line:focus{ border-bottom:2px solid #6B747C; box-shadow:none; }
+#contact .phone-group .input-group-text{ border:0; border-bottom:1px solid #AEB7BF; border-radius:0; background:transparent; padding:10px 12px; color:var(--muted); }
+#contact .phone-group .input-group-text img{ width:20px; height:15px; }
+#contact textarea.form-line{ height:120px; resize:none; }
+#contact .contact-btn{ margin-top:24px; }
+#contact .consent{ font-size:12px; color:#8A929A; margin-top:8px; max-width:70ch; }
+#contact .contact-bottom{ margin-top:40px; display:flex; flex-wrap:wrap; align-items:center; gap:12px; }
+#contact .contact-copy{ font-size:12px; color:#8A929A; line-height:1.5; margin:0; }
+#contact .contact-bottom .links{ display:flex; flex-wrap:wrap; align-items:center; gap:24px; }
+#contact .contact-link{ font-size:12px; color:var(--muted); text-decoration:none; display:flex; align-items:center; }
+#contact .contact-link:hover{ color:#2B2B2B; }
+#contact .link-dot{ display:inline-block; width:14px; height:14px; border:1px solid #D0D6DC; border-radius:50%; margin-left:6px; }
+@media (max-width:767.98px){ #contact .contact-bottom{ flex-direction:column; align-items:flex-start; gap:10px; } #contact .contact-bottom .links{ flex-direction:column; align-items:flex-start; gap:10px; } }
+
+/* Back to top button */
+.back-to-top{ position:fixed; bottom:1.5rem; right:1.5rem; width:44px; height:44px; border-radius:50%; border:1px solid rgba(0,0,0,.15); background:var(--bg); color:var(--ink); display:flex; align-items:center; justify-content:center; box-shadow:0 4px 8px rgba(0,0,0,.1); opacity:.8; text-decoration:none; }
+.back-to-top:hover{ background:#bcc4c9; }
 </style>
 </head>
 <body id="top">
@@ -462,44 +495,55 @@ section { padding:4rem 0; }
     </div>
   </div>
 </section>
-<section id="contact" style="background:var(--bg);">
+<section id="contact">
   <div class="container">
-    <h2 class="text-center mb-5">СВЯЖИТЕСЬ СО МНОЙ УДОБНЫМ СПОСОБОМ</h2>
-    <div class="row g-4">
-      <div class="col-md-6">
-        <p class="h4 mb-4">Тел.: <a href="tel:+79165240129">+7 (916) 524-01-29</a><br>Email: <a href="mailto:lawyer.rus@bk.ru">lawyer.rus@bk.ru</a></p>
-        <ul class="list-unstyled">
-          <li>WhatsApp</li>
-          <li>Telegram</li>
-          <li>Instagram</li>
-        </ul>
+    <h2 class="contact-title">СВЯЖИТЕСЬ СО МНОЙ<br>УДОБНЫМ СПОСОБОМ</h2>
+    <div class="row contact-grid" style="--bs-gutter-x:2rem;">
+      <div class="col-md-5">
+        <div class="contact-info">
+          <a href="tel:+79165240129" class="contact-phone">+7 (916) 524-01-29</a>
+          <a href="mailto:lawyer.rus@bk.ru" class="contact-email">lawyer.rus@bk.ru</a>
+          <ul class="messenger-list">
+            <li>WhatsApp</li>
+            <li>Telegram</li>
+            <li>Instagram</li>
+          </ul>
+        </div>
       </div>
-      <div class="col-md-6">
-        <form>
-          <div class="mb-3">
+      <div class="col-md-7">
+        <form class="contact-form">
+          <div class="mb-4">
             <label for="name" class="form-label">Как вас зовут?</label>
-            <input type="text" class="form-control" id="name" required>
+            <input type="text" class="form-line w-100" id="name" required>
           </div>
-          <div class="mb-3">
+          <div class="mb-4">
             <label for="phone" class="form-label">Телефон</label>
-            <input type="tel" class="form-control" id="phone">
+            <div class="input-group phone-group">
+              <span class="input-group-text"><img src="https://flagcdn.com/w20/ru.png" alt="RU" class="me-1">+7</span>
+              <input type="tel" class="form-line flex-fill" id="phone">
+            </div>
           </div>
-          <div class="mb-3">
+          <div class="mb-4">
             <label for="message" class="form-label">Чем я могу помочь?</label>
-            <textarea class="form-control" id="message" rows="4"></textarea>
+            <textarea class="form-line w-100" id="message"></textarea>
           </div>
-          <button type="submit" class="btn btn-accent rounded-pill px-4">Оставить заявку</button>
-          <p class="small text-muted mt-2 mb-0">Нажимая на кнопку, вы соглашаетесь с политикой конфиденциальности</p>
+          <div class="text-end">
+            <button type="submit" class="btn btn-accent rounded-pill contact-btn">Оставить заявку</button>
+            <p class="consent">Нажимая на кнопку, вы соглашаетесь с политикой конфиденциальности</p>
+          </div>
         </form>
+      </div>
+    </div>
+    <div class="contact-bottom">
+      <p class="contact-copy">© 2021 Член ассоциации юристов / Никифорова Екатерина Сергеевна</p>
+      <div class="links">
+        <a href="#" class="contact-link">Политика конфиденциальности<span class="link-dot"></span></a>
+        <a href="#" class="contact-link">Разработка сайта<span class="link-dot"></span></a>
       </div>
     </div>
   </div>
 </section>
-<footer class="border-top text-center py-3 position-relative">
-  <p class="small mb-1">© 2021 Член ассоциации юристов — Никифорова Екатерина Сергеевна</p>
-  <p class="small mb-0"><a href="#" class="text-decoration-none me-3">Политика конфиденциальности</a><a href="#" class="text-decoration-none">Разработка сайта</a></p>
-</footer>
-<a href="#top" class="btn btn-accent rounded-circle p-3 position-fixed bottom-0 end-0 m-4 fixed-up" aria-label="Наверх">
+<a href="#top" class="back-to-top" aria-label="Наверх">
   <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M8 3.5l-4 4h2.5v5h3v-5H12l-4-4z"/></svg>
 </a>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Rework contact section into left contacts and right form with minimal underline inputs
- Add bottom links and redesigned back-to-top button
- Apply new styles for phone prefix, messenger list, and consent text

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68aeb7fa77d8832cb0f1fa1cd26acb12